### PR TITLE
Simplify desktop nav and remove inorganic styling

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import {
 import React from 'react';
 import { Header } from './components/Header';
 import { Menu } from './components/Menu';
+import { Footer } from './components/Footer';
 import './common.css';
 import { QueryClient, QueryClientProvider, useQuery } from '@tanstack/react-query';
 import { fetchTpsStats } from './apis/fetchTpsStats';
@@ -41,10 +42,10 @@ const useStyles = createStyles((theme) => ({
       width: '100%',
       
       '@media (min-width: 1280px)': {
-        marginLeft: '280px',
+        marginLeft: '220px',
         paddingLeft: '48px',
         paddingRight: '48px',
-        maxWidth: 'calc(100% - 280px)',
+        maxWidth: 'calc(100% - 220px)',
       },
     },
   },
@@ -73,6 +74,7 @@ const AppContainer = () => {
       className={classes.appShell}
     >
       <NavigationRouter />
+      <Footer />
     </AppShell>
   );
 };
@@ -125,10 +127,10 @@ export default function App() {
               primaryColor: 'brand',
               defaultRadius: 'md',
               shadows: {
-                sm: '0 2px 4px rgba(26, 24, 22, 0.04), 0 1px 2px rgba(26, 24, 22, 0.02)',
-                md: '0 8px 24px rgba(26, 24, 22, 0.06), 0 4px 8px rgba(26, 24, 22, 0.03)',
-                lg: '0 24px 48px rgba(26, 24, 22, 0.1), 0 12px 24px rgba(26, 24, 22, 0.05)',
-                xl: '0 32px 64px rgba(26, 24, 22, 0.12), 0 16px 32px rgba(26, 24, 22, 0.06)',
+                sm: '0 1px 3px rgba(0, 0, 0, 0.06)',
+                md: '0 2px 8px rgba(0, 0, 0, 0.08)',
+                lg: '0 4px 16px rgba(0, 0, 0, 0.1)',
+                xl: '0 8px 24px rgba(0, 0, 0, 0.12)',
               },
               other: {
                 transitionTimingFunction: 'cubic-bezier(0.165, 0.84, 0.44, 1)',

--- a/src/common.css
+++ b/src/common.css
@@ -41,24 +41,22 @@
   --color-warning: #F59E0B;
   --color-error: #EF4444;
   
-  /* Gradients - Refined, subtle gradients */
+  /* Gradients - Keep simple */
   --gradient-primary: linear-gradient(135deg, #FF6B35 0%, #FF8F6B 100%);
   --gradient-dark: linear-gradient(135deg, #1A1816 0%, #2D2926 100%);
   --gradient-warm: linear-gradient(135deg, #FFF7ED 0%, #FFEDD5 100%);
-  --gradient-glow: radial-gradient(ellipse at 50% 0%, rgba(255, 107, 53, 0.12) 0%, transparent 60%);
-  --gradient-mesh: radial-gradient(at 40% 20%, rgba(255, 143, 107, 0.08) 0%, transparent 50%),
-                   radial-gradient(at 80% 0%, rgba(99, 102, 241, 0.06) 0%, transparent 50%),
-                   radial-gradient(at 0% 50%, rgba(255, 107, 53, 0.05) 0%, transparent 50%);
+  --gradient-glow: none;
+  --gradient-mesh: none;
   
-  /* Shadows - Refined depth system with warm tones */
-  --shadow-xs: 0 1px 2px rgba(26, 24, 22, 0.04);
-  --shadow-sm: 0 2px 4px rgba(26, 24, 22, 0.04), 0 1px 2px rgba(26, 24, 22, 0.02);
-  --shadow-card: 0 4px 12px rgba(26, 24, 22, 0.04), 0 2px 4px rgba(26, 24, 22, 0.02);
-  --shadow-md: 0 8px 24px rgba(26, 24, 22, 0.06), 0 4px 8px rgba(26, 24, 22, 0.03);
-  --shadow-hover: 0 16px 40px rgba(26, 24, 22, 0.08), 0 8px 16px rgba(26, 24, 22, 0.04);
-  --shadow-lg: 0 24px 48px rgba(26, 24, 22, 0.1), 0 12px 24px rgba(26, 24, 22, 0.05);
-  --shadow-float: 0 32px 64px rgba(26, 24, 22, 0.12), 0 16px 32px rgba(26, 24, 22, 0.06);
-  --shadow-glow: 0 0 0 1px rgba(255, 107, 53, 0.2), 0 4px 16px rgba(255, 107, 53, 0.15);
+  /* Shadows - Simple, minimal depth */
+  --shadow-xs: 0 1px 2px rgba(0, 0, 0, 0.04);
+  --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.06);
+  --shadow-card: 0 1px 3px rgba(0, 0, 0, 0.06);
+  --shadow-md: 0 2px 8px rgba(0, 0, 0, 0.08);
+  --shadow-hover: 0 4px 12px rgba(0, 0, 0, 0.1);
+  --shadow-lg: 0 4px 16px rgba(0, 0, 0, 0.1);
+  --shadow-float: 0 8px 24px rgba(0, 0, 0, 0.12);
+  --shadow-glow: none;
   
   /* Spacing & Layout */
   --header-height: 76px;
@@ -107,19 +105,6 @@ body {
   font-feature-settings: 'ss01' on, 'ss02' on, 'cv01' on;
 }
 
-/* Subtle noise texture overlay for depth */
-body::before {
-  content: '';
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  pointer-events: none;
-  z-index: 9999;
-  opacity: 0.025;
-  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)'/%3E%3C/svg%3E");
-}
 
 /* ═══════════════════════════════════════════════════════════════════
    CUSTOM SCROLLBAR
@@ -151,18 +136,14 @@ body::before {
    UTILITY CLASSES
    ═══════════════════════════════════════════════════════════════════ */
 
-/* Glass morphism panels */
+/* Panels */
 .glass-panel {
-  background: rgba(255, 255, 255, 0.75);
-  backdrop-filter: blur(24px) saturate(180%);
-  -webkit-backdrop-filter: blur(24px) saturate(180%);
-  border: 1px solid rgba(255, 255, 255, 0.5);
+  background: #FFFFFF;
+  border: 1px solid var(--border-subtle);
 }
 
 .glass-panel-dark {
-  background: rgba(26, 24, 22, 0.85);
-  backdrop-filter: blur(24px) saturate(180%);
-  -webkit-backdrop-filter: blur(24px) saturate(180%);
+  background: var(--bg-inverse);
   border: 1px solid rgba(255, 255, 255, 0.08);
 }
 
@@ -268,14 +249,6 @@ body::before {
   }
 }
 
-@keyframes glow-pulse {
-  0%, 100% {
-    box-shadow: 0 0 20px rgba(255, 107, 53, 0.3);
-  }
-  50% {
-    box-shadow: 0 0 40px rgba(255, 107, 53, 0.5);
-  }
-}
 
 /* Animation utilities */
 .animate-fade-in {

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -1,0 +1,187 @@
+import React from 'react';
+import { createStyles } from '@mantine/core';
+import { Link } from 'react-router-dom';
+
+const useStyles = createStyles((theme) => ({
+  footer: {
+    borderTop: '1px solid var(--border-subtle)',
+    padding: '40px 0 32px',
+    marginTop: '80px',
+  },
+
+  inner: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    gap: '48px',
+    flexWrap: 'wrap',
+
+    [theme.fn.smallerThan('sm')]: {
+      flexDirection: 'column',
+      gap: '32px',
+    },
+  },
+
+  brand: {
+    maxWidth: '260px',
+
+    [theme.fn.smallerThan('sm')]: {
+      maxWidth: '100%',
+    },
+  },
+
+  brandName: {
+    fontFamily: 'var(--font-display)',
+    fontWeight: 800,
+    fontSize: '18px',
+    color: 'var(--text-primary)',
+    letterSpacing: '-0.02em',
+    marginBottom: '8px',
+  },
+
+  brandDescription: {
+    fontSize: '13px',
+    color: 'var(--text-tertiary)',
+    lineHeight: 1.6,
+  },
+
+  columns: {
+    display: 'flex',
+    gap: '48px',
+    flexWrap: 'wrap',
+
+    [theme.fn.smallerThan('sm')]: {
+      gap: '32px',
+    },
+  },
+
+  column: {},
+
+  columnTitle: {
+    fontSize: '11px',
+    fontWeight: 700,
+    textTransform: 'uppercase',
+    letterSpacing: '0.08em',
+    color: 'var(--text-tertiary)',
+    marginBottom: '12px',
+    fontFamily: 'var(--font-body)',
+  },
+
+  columnLinks: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '8px',
+  },
+
+  link: {
+    fontSize: '13px',
+    color: 'var(--text-secondary)',
+    textDecoration: 'none',
+    fontFamily: 'var(--font-body)',
+    transition: 'color 0.15s ease',
+
+    '&:hover': {
+      color: 'var(--text-primary)',
+    },
+  },
+
+  bottom: {
+    borderTop: '1px solid var(--border-subtle)',
+    marginTop: '32px',
+    paddingTop: '20px',
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+
+    [theme.fn.smallerThan('sm')]: {
+      flexDirection: 'column',
+      alignItems: 'flex-start',
+      gap: '8px',
+    },
+  },
+
+  copyright: {
+    fontSize: '12px',
+    color: 'var(--text-tertiary)',
+    fontFamily: 'var(--font-body)',
+  },
+
+  bottomLinks: {
+    display: 'flex',
+    gap: '16px',
+  },
+
+  bottomLink: {
+    fontSize: '12px',
+    color: 'var(--text-tertiary)',
+    textDecoration: 'none',
+    fontFamily: 'var(--font-body)',
+    transition: 'color 0.15s ease',
+
+    '&:hover': {
+      color: 'var(--text-secondary)',
+    },
+  },
+}));
+
+export const Footer = () => {
+  const { classes } = useStyles();
+
+  return (
+    <footer className={classes.footer}>
+      <div className={classes.inner}>
+        <div className={classes.brand}>
+          <div className={classes.brandName}>SolApps</div>
+          <div className={classes.brandDescription}>
+            A curated directory of applications and tools built on Solana.
+          </div>
+        </div>
+
+        <div className={classes.columns}>
+          <div className={classes.column}>
+            <div className={classes.columnTitle}>Directory</div>
+            <div className={classes.columnLinks}>
+              <Link to="/category/curated" className={classes.link}>Curated</Link>
+              <Link to="/category/defi" className={classes.link}>DeFi</Link>
+              <Link to="/category/nft" className={classes.link}>NFTs</Link>
+              <Link to="/category/tools" className={classes.link}>Tools</Link>
+            </div>
+          </div>
+
+          <div className={classes.column}>
+            <div className={classes.columnTitle}>Resources</div>
+            <div className={classes.columnLinks}>
+              <a href="https://docs.solworks.dev" target="_blank" rel="noreferrer" className={classes.link}>
+                Documentation
+              </a>
+              <a href="https://k722zc9ivtg.typeform.com/to/uN4Pklej" target="_blank" rel="noreferrer" className={classes.link}>
+                Get listed
+              </a>
+              <a href="https://k722zc9ivtg.typeform.com/to/OHTjdlkb" target="_blank" rel="noreferrer" className={classes.link}>
+                Partnerships
+              </a>
+            </div>
+          </div>
+
+          <div className={classes.column}>
+            <div className={classes.columnTitle}>Ecosystem</div>
+            <div className={classes.columnLinks}>
+              <a href="https://solworks.dev" target="_blank" rel="noreferrer" className={classes.link}>SolWorks</a>
+              <a href="https://sujiko.trade" target="_blank" rel="noreferrer" className={classes.link}>Sujiko</a>
+              <a href="https://soltoolkit.dev" target="_blank" rel="noreferrer" className={classes.link}>SolToolkit</a>
+              <a href="https://soldisperse.app" target="_blank" rel="noreferrer" className={classes.link}>SolDisperse</a>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className={classes.bottom}>
+        <span className={classes.copyright}>&copy; {new Date().getFullYear()} SolApps</span>
+        <div className={classes.bottomLinks}>
+          <a href="https://solworks.dev" target="_blank" rel="noreferrer" className={classes.bottomLink}>
+            Built by SolWorks
+          </a>
+        </div>
+      </div>
+    </footer>
+  );
+};

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -5,45 +5,26 @@ import {
   Group,
   Burger,
   Select,
-  keyframes,
 } from '@mantine/core';
 import { Search, Command, Bolt } from 'tabler-icons-react';
 import { useNavigate } from 'react-router-dom';
 import { appList } from '@solworks/application-registry';
 import { formatLink } from '../../Common';
 
-const pulse = keyframes({
-  '0%, 100%': {
-    boxShadow: '0 0 0 0 rgba(16, 185, 129, 0.5)',
-    transform: 'scale(1)',
-  },
-  '50%': {
-    boxShadow: '0 0 0 8px rgba(16, 185, 129, 0)',
-    transform: 'scale(1.1)',
-  },
-});
-
-const shimmer = keyframes({
-  '0%': { backgroundPosition: '-200% 0' },
-  '100%': { backgroundPosition: '200% 0' },
-});
-
 const useStyles = createStyles((theme) => ({
   header: {
-    backgroundColor: 'rgba(248, 246, 243, 0.85)',
-    backdropFilter: 'blur(24px) saturate(180%)',
-    WebkitBackdropFilter: 'blur(24px) saturate(180%)',
+    backgroundColor: 'var(--bg-app)',
     borderBottom: '1px solid var(--border-subtle)',
     height: 'var(--header-height)',
     position: 'fixed',
     top: 0,
     zIndex: 100,
     width: '100%',
-    transition: 'all 0.4s var(--ease-out-quart)',
+    transition: 'background-color 0.2s ease, box-shadow 0.2s ease',
   },
 
   headerScrolled: {
-    backgroundColor: 'rgba(255, 255, 255, 0.95)',
+    backgroundColor: 'var(--bg-surface)',
     boxShadow: 'var(--shadow-sm)',
   },
 
@@ -71,61 +52,26 @@ const useStyles = createStyles((theme) => ({
     textDecoration: 'none',
     display: 'flex',
     alignItems: 'center',
-    gap: '14px',
-    padding: '6px 16px 6px 6px',
-    borderRadius: 'var(--radius-full)',
-    transition: 'all 0.3s var(--ease-out-quart)',
-    border: '1px solid transparent',
+    gap: '12px',
+    padding: '4px 12px 4px 4px',
+    borderRadius: 'var(--radius-md)',
+    transition: 'background-color 0.15s ease',
 
     '&:hover': {
-      backgroundColor: 'rgba(255, 107, 53, 0.04)',
-      borderColor: 'rgba(255, 107, 53, 0.1)',
-
-      '& .logo-icon': {
-        transform: 'rotate(-8deg) scale(1.05)',
-        boxShadow: '0 8px 24px rgba(255, 107, 53, 0.35)',
-      },
-
-      '& .logo-bolt': {
-        transform: 'rotate(15deg)',
-      }
+      backgroundColor: 'var(--bg-secondary)',
     },
-
-    '&:active': {
-      transform: 'scale(0.98)',
-    }
   },
 
   logoIcon: {
-    width: '42px',
-    height: '42px',
-    background: 'linear-gradient(135deg, #FF6B35 0%, #FF8F6B 50%, #FF6B35 100%)',
-    backgroundSize: '200% 200%',
-    borderRadius: '12px',
+    width: '38px',
+    height: '38px',
+    background: 'var(--color-primary)',
+    borderRadius: '10px',
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
     color: 'white',
-    boxShadow: '0 4px 16px rgba(255, 107, 53, 0.3), inset 0 1px 0 rgba(255, 255, 255, 0.2)',
-    transition: 'all 0.35s var(--ease-out-back)',
-    position: 'relative',
-    overflow: 'hidden',
-
-    '&::before': {
-      content: '""',
-      position: 'absolute',
-      top: 0,
-      left: 0,
-      right: 0,
-      bottom: 0,
-      background: 'linear-gradient(135deg, rgba(255,255,255,0.25) 0%, transparent 50%)',
-      borderRadius: '12px',
-    }
-  },
-
-  logoBolt: {
-    transition: 'transform 0.35s var(--ease-out-back)',
-    filter: 'drop-shadow(0 1px 2px rgba(0,0,0,0.1))',
+    transition: 'transform 0.2s ease',
   },
 
   logoText: {
@@ -166,13 +112,13 @@ const useStyles = createStyles((theme) => ({
   },
 
   searchInput: {
-    backgroundColor: 'rgba(26, 24, 22, 0.04)',
-    border: '1px solid transparent',
+    backgroundColor: 'var(--bg-secondary)',
+    border: '1px solid var(--border-subtle)',
     borderRadius: 'var(--radius-full)',
-    height: '48px',
+    height: '44px',
     paddingLeft: '48px',
     paddingRight: '64px',
-    transition: 'all 0.3s var(--ease-out-quart)',
+    transition: 'border-color 0.15s ease, box-shadow 0.15s ease',
     fontWeight: 500,
     fontSize: '14px',
     fontFamily: 'var(--font-body)',
@@ -182,11 +128,11 @@ const useStyles = createStyles((theme) => ({
     '&:focus': {
       backgroundColor: 'white',
       border: '1px solid var(--color-primary)',
-      boxShadow: '0 0 0 4px var(--color-primary-subtle)',
+      boxShadow: '0 0 0 2px rgba(255, 107, 53, 0.15)',
     },
 
     '&:hover:not(:focus)': {
-      backgroundColor: 'rgba(26, 24, 22, 0.06)',
+      borderColor: 'var(--border-default)',
     },
 
     '&::placeholder': {
@@ -211,71 +157,12 @@ const useStyles = createStyles((theme) => ({
     fontFamily: 'var(--font-body)',
     color: 'var(--text-tertiary)',
     gap: '2px',
-    transition: 'all 0.2s ease',
-  },
-
-  rightSection: {
-    display: 'flex',
-    alignItems: 'center',
-    gap: '16px',
   },
 
   burger: {
     [theme.fn.largerThan('xl')]: {
       display: 'none',
     },
-  },
-
-  statItem: {
-    display: 'flex',
-    alignItems: 'center',
-    gap: '12px',
-    padding: '8px 14px',
-    borderRadius: 'var(--radius-full)',
-    background: 'var(--color-success-subtle)',
-    border: '1px solid rgba(16, 185, 129, 0.15)',
-    transition: 'all 0.2s ease',
-
-    '&:hover': {
-      background: 'rgba(16, 185, 129, 0.12)',
-    },
-
-    [theme.fn.smallerThan('sm')]: {
-      display: 'none',
-    }
-  },
-
-  statContent: {
-    display: 'flex',
-    flexDirection: 'column',
-    alignItems: 'flex-start',
-    lineHeight: 1.2,
-  },
-
-  statLabel: {
-    fontSize: '9px',
-    textTransform: 'uppercase',
-    letterSpacing: '0.08em',
-    color: 'var(--color-success)',
-    fontWeight: 700,
-    fontFamily: 'var(--font-body)',
-  },
-
-  statValue: {
-    fontSize: '14px',
-    fontWeight: 700,
-    fontFamily: 'var(--font-display)',
-    fontVariantNumeric: 'tabular-nums',
-    color: 'var(--text-primary)',
-  },
-
-  pulseDot: {
-    width: '8px',
-    height: '8px',
-    borderRadius: '50%',
-    backgroundColor: 'var(--color-success)',
-    animation: `${pulse} 2s infinite ease-in-out`,
-    flexShrink: 0,
   },
 }));
 
@@ -286,7 +173,7 @@ interface HeaderProps {
   solQuery: any;
 }
 
-export const Header: FC<HeaderProps> = ({ onBurgerClick, openMenu, tpsQuery, solQuery }) => {
+export const Header: FC<HeaderProps> = ({ onBurgerClick, openMenu }) => {
   const { classes, cx } = useStyles();
   const navigate = useNavigate();
   const [scrolled, setScrolled] = useState(false);
@@ -321,8 +208,8 @@ export const Header: FC<HeaderProps> = ({ onBurgerClick, openMenu, tpsQuery, sol
             size="sm"
           />
           <a href="/" className={classes.logo}>
-            <div className={`${classes.logoIcon} logo-icon`}>
-              <Bolt size={22} strokeWidth={2.5} className={`${classes.logoBolt} logo-bolt`} />
+            <div className={classes.logoIcon}>
+              <Bolt size={22} strokeWidth={2.5} />
             </div>
             <div className={classes.logoText}>
               <span className={classes.logoTitle}>SolApps</span>
@@ -371,18 +258,6 @@ export const Header: FC<HeaderProps> = ({ onBurgerClick, openMenu, tpsQuery, sol
               },
             }}
           />
-        </div>
-
-        <div className={classes.rightSection}>
-          <div className={classes.statItem}>
-            <span className={classes.pulseDot} />
-            <div className={classes.statContent}>
-              <span className={classes.statLabel}>Live TPS</span>
-              <span className={classes.statValue}>
-                {tpsQuery.data ? Math.round(tpsQuery.data.data.networkInfo.tps).toLocaleString() : '—'}
-              </span>
-            </div>
-          </div>
         </div>
       </div>
     </MantineHeader>

--- a/src/components/LinksGroup/index.tsx
+++ b/src/components/LinksGroup/index.tsx
@@ -24,7 +24,7 @@ const useStyles = createStyles((theme, _params, getRef) => ({
     fontSize: '14px',
     fontFamily: 'var(--font-body)',
     borderRadius: 'var(--radius-md)',
-    transition: 'all 0.25s var(--ease-out-quart)',
+    transition: 'background-color 0.15s ease, color 0.15s ease',
     marginBottom: '2px',
     textDecoration: 'none',
     cursor: 'pointer',
@@ -36,7 +36,6 @@ const useStyles = createStyles((theme, _params, getRef) => ({
 
       [`& .${getRef('icon')}`]: {
         color: 'var(--color-primary)',
-        transform: 'scale(1.1)',
       },
     },
   },
@@ -62,7 +61,7 @@ const useStyles = createStyles((theme, _params, getRef) => ({
     fontSize: '13px',
     color: 'var(--text-secondary)',
     fontFamily: 'var(--font-body)',
-    transition: 'all 0.25s var(--ease-out-quart)',
+    transition: 'background-color 0.15s ease, color 0.15s ease',
     borderRadius: 'var(--radius-md)',
     position: 'relative',
     marginBottom: '2px',
@@ -74,11 +73,11 @@ const useStyles = createStyles((theme, _params, getRef) => ({
       left: '28px',
       top: '50%',
       transform: 'translateY(-50%)',
-      width: '6px',
-      height: '6px',
+      width: '5px',
+      height: '5px',
       borderRadius: '50%',
       backgroundColor: 'var(--border-default)',
-      transition: 'all 0.25s var(--ease-out-quart)',
+      transition: 'background-color 0.15s ease',
     },
 
     '&:hover': {
@@ -88,7 +87,6 @@ const useStyles = createStyles((theme, _params, getRef) => ({
 
       '&::before': {
         backgroundColor: 'var(--color-primary)',
-        transform: 'translateY(-50%) scale(1.2)',
       },
 
       '& .external-icon': {
@@ -116,7 +114,7 @@ const useStyles = createStyles((theme, _params, getRef) => ({
   icon: {
     ref: getRef('icon'),
     color: 'var(--text-tertiary)',
-    transition: 'all 0.25s var(--ease-out-quart)',
+    transition: 'color 0.15s ease',
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',

--- a/src/components/Menu/index.tsx
+++ b/src/components/Menu/index.tsx
@@ -13,33 +13,22 @@ const fadeIn = keyframes({
 const useStyles = createStyles((theme) => ({
   navbar: {
     backgroundColor: 'var(--bg-app)',
-    borderRight: 'none',
+    borderRight: '1px solid var(--border-subtle)',
     position: 'fixed',
     top: 'var(--header-height)',
     left: 0,
     height: 'calc(100vh - var(--header-height))',
-    paddingTop: '24px',
+    paddingTop: '20px',
     zIndex: 50,
     overflowY: 'auto',
 
-    '&::after': {
-      content: '""',
-      position: 'absolute',
-      top: 0,
-      right: 0,
-      width: '1px',
-      height: '100%',
-      background: 'linear-gradient(to bottom, var(--border-subtle), transparent)',
-      pointerEvents: 'none',
-    },
-
     '@media (max-width: 1279px)': {
       backgroundColor: 'var(--bg-surface)',
-      boxShadow: 'var(--shadow-xl)',
+      boxShadow: 'var(--shadow-md)',
     },
 
     '@media (min-width: 1280px)': {
-      width: '280px',
+      width: '220px',
     }
   },
 
@@ -82,10 +71,10 @@ const useStyles = createStyles((theme) => ({
   },
 
   footerContent: {
-    padding: '16px',
-    borderRadius: 'var(--radius-lg)',
+    padding: '14px',
+    borderRadius: 'var(--radius-md)',
     background: 'var(--bg-secondary)',
-    marginBottom: '16px',
+    marginBottom: '12px',
   },
 
   footerTitle: {
@@ -144,15 +133,14 @@ const useStyles = createStyles((theme) => ({
   },
 
   logoIcon: {
-    width: '38px',
-    height: '38px',
-    background: 'linear-gradient(135deg, #FF6B35 0%, #FF8F6B 100%)',
-    borderRadius: '10px',
+    width: '34px',
+    height: '34px',
+    background: 'var(--color-primary)',
+    borderRadius: '8px',
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
     color: 'white',
-    boxShadow: '0 4px 12px rgba(255, 107, 53, 0.25)',
   },
 
   logoTextGroup: {
@@ -198,7 +186,7 @@ export const Menu: FC<{ showNavbar?: boolean; hideMenu?: () => void; isMenuOpen:
 
   return (
     <Navbar
-      width={{ base: 300 }}
+      width={{ base: 220 }}
       p="md"
       className={classes.navbar}
       hidden={!showNavbar}


### PR DESCRIPTION
## Summary
- Narrowed left sidebar from 280px to 220px so main content has more horizontal space
- Removed glass morphism (backdrop-filter blur), noise texture overlay, gradient glows, multi-layer shadows, and pulsing animations that felt AI-generated
- Simplified logo icons to flat color, toned down hover effects, and flattened shadow system
- Removed Live TPS stat from header
- Added a simple page footer with directory links, resources, and ecosystem columns

## Test plan
- [ ] Verify sidebar is narrower and main content has more room on desktop (>=1280px)
- [ ] Verify header no longer shows TPS stat
- [ ] Verify footer renders at the bottom of all pages with working links
- [ ] Verify mobile burger menu still works correctly
- [ ] Check that hover states on nav items are subtle, no icon scaling or glow effects

🤖 Generated with [Claude Code](https://claude.com/claude-code)