### PR TITLE
Improve SolApps crawl and indexing signals

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,9 @@
     "storybook": "NODE_OPTIONS=--openssl-legacy-provider start-storybook",
     "dev": "npm run storybook",
     "start": "react-scripts start",
-    "build": "react-scripts build && npm run generate-sitemap",
+    "build": "react-scripts build && npm run generate-sitemap && npm run generate-seo-pages",
     "generate-sitemap": "node scripts/generate-sitemap.js",
+    "generate-seo-pages": "node scripts/generate-seo-pages.js",
     "pretty": "npx prettier --write ."
   },
   "eslintConfig": {

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,0 +1,3 @@
+https://www.solapps.dev/* https://solapps.dev/:splat 301!
+http://www.solapps.dev/* https://solapps.dev/:splat 301!
+/* /index.html 200

--- a/public/index.html
+++ b/public/index.html
@@ -398,6 +398,17 @@
         <li><a href="/category/staking">Staking</a></li>
         <li><a href="/category/payments">Payments</a></li>
       </ul>
+      <p>Popular apps:</p>
+      <ul style="text-align:left;list-style:none;padding:0;">
+        <li><a href="/apps/jupiter">Jupiter</a></li>
+        <li><a href="/apps/orca">Orca</a></li>
+        <li><a href="/apps/raydium">Raydium</a></li>
+        <li><a href="/apps/phantom">Phantom</a></li>
+        <li><a href="/apps/solflare">Solflare</a></li>
+        <li><a href="/apps/magic_eden">Magic Eden</a></li>
+        <li><a href="/apps/solscan">Solscan</a></li>
+        <li><a href="/apps/marinade_finance">Marinade Finance</a></li>
+      </ul>
       <p>Please enable JavaScript for the full experience.</p>
     </div>
   </noscript>

--- a/scripts/generate-seo-pages.js
+++ b/scripts/generate-seo-pages.js
@@ -1,0 +1,191 @@
+const fs = require('fs');
+const path = require('path');
+const { appList } = require('@solworks/application-registry');
+
+const SITE_URL = 'https://solapps.dev';
+const DEFAULT_IMAGE = `${SITE_URL}/og-image.png`;
+const buildDir = path.join(__dirname, '..', 'build');
+const templatePath = path.join(buildDir, 'index.html');
+
+function encodeString(text) {
+  return text.trim().replace(/\s+/g, '_').toLowerCase().replace(/\W/g, '');
+}
+
+function escapeHtml(value) {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function escapeScript(value) {
+  return JSON.stringify(value).replace(/</g, '\\u003c');
+}
+
+function replaceOrInsert(html, pattern, replacement) {
+  if (pattern.test(html)) {
+    return html.replace(pattern, replacement);
+  }
+
+  return html.replace('</head>', `  ${replacement}\n</head>`);
+}
+
+function renderPage(template, page) {
+  const title = page.title;
+  const description = page.description;
+  const keywords = page.keywords.join(', ');
+  const image = page.image || DEFAULT_IMAGE;
+  const structuredData = page.structuredData
+    ? `  <script type="application/ld+json">${escapeScript(page.structuredData)}</script>\n`
+    : '';
+
+  let html = template
+    .replace(/<title>[\s\S]*?<\/title>/, `<title>${escapeHtml(title)}</title>`);
+
+  const replacements = [
+    [/<meta name="title" content="[^"]*"[^>]*\/>/, `<meta name="title" content="${escapeHtml(title)}" />`],
+    [/<meta name="description" content="[^"]*"[^>]*\/>/, `<meta name="description" content="${escapeHtml(description)}" />`],
+    [/<meta name="keywords" content="[^"]*"[^>]*\/>/, `<meta name="keywords" content="${escapeHtml(keywords)}" />`],
+    [/<link rel="canonical" href="[^"]*"[^>]*\/>/, `<link rel="canonical" href="${escapeHtml(page.url)}" />`],
+    [/<meta property="og:url" content="[^"]*"[^>]*\/>/, `<meta property="og:url" content="${escapeHtml(page.url)}" />`],
+    [/<meta property="og:title" content="[^"]*"[^>]*\/>/, `<meta property="og:title" content="${escapeHtml(title)}" />`],
+    [/<meta property="og:description" content="[^"]*"[^>]*\/>/, `<meta property="og:description" content="${escapeHtml(description)}" />`],
+    [/<meta property="og:image" content="[^"]*"[^>]*\/>/, `<meta property="og:image" content="${escapeHtml(image)}" />`],
+    [/<meta name="twitter:url" content="[^"]*"[^>]*\/>/, `<meta name="twitter:url" content="${escapeHtml(page.url)}" />`],
+    [/<meta name="twitter:title" content="[^"]*"[^>]*\/>/, `<meta name="twitter:title" content="${escapeHtml(title)}" />`],
+    [/<meta name="twitter:description" content="[^"]*"[^>]*\/>/, `<meta name="twitter:description" content="${escapeHtml(description)}" />`],
+    [/<meta name="twitter:image" content="[^"]*"[^>]*\/>/, `<meta name="twitter:image" content="${escapeHtml(image)}" />`],
+  ];
+
+  replacements.forEach(([pattern, replacement]) => {
+    html = replaceOrInsert(html, pattern, `  ${replacement}`);
+  });
+
+  if (structuredData) {
+    html = html.replace('</head>', `${structuredData}</head>`);
+  }
+
+  return html;
+}
+
+function writePage(route, html) {
+  const outputDir = path.join(buildDir, route);
+  fs.mkdirSync(outputDir, { recursive: true });
+  fs.writeFileSync(path.join(outputDir, 'index.html'), html);
+}
+
+function categoryPages() {
+  const categoriesByValue = new Map();
+  [
+    { value: 'curated', heading_label: 'Curated', tag_label: 'Curated' },
+    ...appList.categories.filter((category) => category.value !== 'curated'),
+  ].forEach((category) => {
+    categoriesByValue.set(category.value, category);
+  });
+
+  const categories = [...categoriesByValue.values()];
+
+  return categories.map((category) => {
+    const apps = category.value === 'curated'
+      ? appList.apps.filter((app) => app.app.is_curated)
+      : appList.apps.filter((app) => app.app.categories[0] === category.value);
+    const url = `${SITE_URL}/category/${category.value}`;
+    const description = `Browse ${apps.length} ${category.heading_label} apps on Solana. Discover the best ${category.heading_label.toLowerCase()} projects in the Solana ecosystem.`;
+
+    return {
+      route: `category/${category.value}`,
+      title: `${category.heading_label} | SolApps`,
+      description,
+      url,
+      keywords: [
+        category.heading_label,
+        `${category.heading_label} Solana`,
+        `Solana ${category.heading_label.toLowerCase()}`,
+        'Solana apps',
+        'Solana dApps',
+        'crypto',
+        'blockchain',
+      ],
+      structuredData: {
+        '@context': 'https://schema.org',
+        '@type': 'CollectionPage',
+        name: `${category.heading_label} Apps on Solana`,
+        description,
+        url,
+        isPartOf: {
+          '@type': 'WebSite',
+          name: 'SolApps',
+          url: SITE_URL,
+        },
+        numberOfItems: apps.length,
+      },
+    };
+  });
+}
+
+function appPages() {
+  return appList.apps
+    .filter((app) => !app.app.is_deprecated)
+    .map((app) => {
+      const category = appList.categories.find((cat) => cat.value === app.app.categories[0]);
+      const url = `${SITE_URL}/apps/${encodeString(app.app.label)}`;
+
+      return {
+        route: `apps/${encodeString(app.app.label)}`,
+        title: `${app.app.label} | SolApps`,
+        description: app.description.short,
+        url,
+        image: app.urls.logo || DEFAULT_IMAGE,
+        keywords: [
+          app.app.label,
+          `${app.app.label} Solana`,
+          category?.heading_label || 'Solana app',
+          'Solana app',
+          'crypto',
+          'blockchain',
+          'Web3',
+        ],
+        structuredData: {
+          '@context': 'https://schema.org',
+          '@type': 'SoftwareApplication',
+          name: app.app.label,
+          description: app.description.short,
+          url,
+          applicationCategory: category?.heading_label || 'Solana app',
+          operatingSystem: 'Web',
+          offers: {
+            '@type': 'Offer',
+            price: '0',
+            priceCurrency: 'USD',
+          },
+          publisher: {
+            '@type': 'Organization',
+            name: 'SolApps',
+            url: SITE_URL,
+          },
+          image: app.urls.logo || DEFAULT_IMAGE,
+          sameAs: app.urls.website,
+        },
+      };
+    });
+}
+
+function generateSeoPages() {
+  if (!fs.existsSync(templatePath)) {
+    console.log('Skipped SEO page generation: build/index.html not found');
+    return;
+  }
+
+  const template = fs.readFileSync(templatePath, 'utf8');
+  const pages = [...categoryPages(), ...appPages()];
+
+  pages.forEach((page) => {
+    writePage(page.route, renderPage(template, page));
+  });
+
+  console.log(`Generated ${pages.length} SEO route snapshots`);
+}
+
+generateSeoPages();

--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -8,22 +8,8 @@ const staticRoutes = [
   { url: '/', priority: 1.0, changefreq: 'daily' },
 ];
 
-const categoryRoutes = [
-  { slug: 'curated', name: 'Curated' },
-  { slug: 'defi', name: 'DeFi' },
-  { slug: 'nft', name: 'NFT' },
-  { slug: 'gaming', name: 'Gaming' },
-  { slug: 'wallet', name: 'Wallet' },
-  { slug: 'dex', name: 'DEX' },
-  { slug: 'tools', name: 'Tools' },
-  { slug: 'social', name: 'Social' },
-  { slug: 'staking', name: 'Staking' },
-  { slug: 'payments', name: 'Payments' },
-];
-
-// Must match the encodeString in src/Common.tsx so URLs are consistent
 function encodeString(text) {
-  return text.replace(' ', '_').toLowerCase().replace(/\W/g, '');
+  return text.trim().replace(/\s+/g, '_').toLowerCase().replace(/\W/g, '');
 }
 
 function escapeXml(str) {
@@ -48,6 +34,13 @@ function generateSitemap() {
       priority: route.priority,
     });
   });
+
+  const categoryRoutes = [
+    { slug: 'curated' },
+    ...appList.categories
+      .filter((category) => category.value !== 'curated')
+      .map((category) => ({ slug: category.value })),
+  ];
 
   categoryRoutes.forEach((category) => {
     urls.push({

--- a/src/Common.tsx
+++ b/src/Common.tsx
@@ -2,7 +2,7 @@ import { useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 
 export function encodeString(text: string) {
-  return text.replace(' ', '_').toLocaleLowerCase().replace(/\W/g, '');
+  return text.trim().replace(/\s+/g, '_').toLowerCase().replace(/\W/g, '');
 }
 
 export function formatLink(appName: string) {

--- a/src/components/ApplicationPage/ApplicationPage.tsx
+++ b/src/components/ApplicationPage/ApplicationPage.tsx
@@ -12,6 +12,7 @@ import { SectionHeader } from '../SectionHeader';
 import { Logo } from '../Logo';
 import ReactMarkdown from 'react-markdown';
 import { ExternalLink, AlertTriangle, ArrowRight } from 'tabler-icons-react';
+import { FourZeroFourView } from '../../views/FourZeroFourView';
 
 export interface ApplicationPageProps {}
 
@@ -324,9 +325,11 @@ export const ApplicationPage: FC<ApplicationPageProps> = () => {
   const [data, setData] = useState<App>();
   const [linkCards, setLinkCards] = useState<JSX.Element[]>([]);
   const [relatedCards, setRelatedCards] = useState<JSX.Element[]>([]);
+  const [isResolved, setIsResolved] = useState(false);
   const { classes } = useStyles();
 
   useEffect(() => {
+    setIsResolved(false);
     const appData = appList.apps.find((app) => encodeString(app.app.label) === id);
     if (appData) {
       setData(appData as App);
@@ -376,10 +379,15 @@ export const ApplicationPage: FC<ApplicationPageProps> = () => {
           </Grid.Col>
         ))
       );
+    } else {
+      setData(undefined);
+      setLinkCards([]);
+      setRelatedCards([]);
     }
+    setIsResolved(true);
   }, [id]);
 
-  if (!data) return null;
+  if (!data) return isResolved ? <FourZeroFourView /> : null;
 
   const category = appList.categories.find((cat) => cat.value === data.app.categories[0]);
 
@@ -390,6 +398,7 @@ export const ApplicationPage: FC<ApplicationPageProps> = () => {
         appDescription={data.description.short}
         appUrl={`https://solapps.dev${formatLink(data.app.label)}`}
         category={category?.heading_label}
+        categorySlug={category?.value}
         logoUrl={data.urls.logo}
         websiteUrl={data.urls.website}
       />
@@ -498,7 +507,7 @@ export const ApplicationPage: FC<ApplicationPageProps> = () => {
               <div className={classes.relatedHeader}>
                 <h2 className={classes.relatedTitle}>Similar Apps</h2>
                 {category && (
-                  <a href={`/categories/${category.value}`} className={classes.viewAllLink}>
+                  <a href={`/category/${category.value}`} className={classes.viewAllLink}>
                     View all {category.heading_label}
                     <ArrowRight size={16} />
                   </a>

--- a/src/components/SEO/index.tsx
+++ b/src/components/SEO/index.tsx
@@ -158,6 +158,7 @@ interface AppSEOProps {
   appDescription: string;
   appUrl: string;
   category?: string;
+  categorySlug?: string;
   logoUrl?: string;
   websiteUrl?: string;
 }
@@ -167,6 +168,7 @@ export const AppSEO = ({
   appDescription,
   appUrl,
   category,
+  categorySlug,
   logoUrl,
   websiteUrl,
 }: AppSEOProps) => {
@@ -206,10 +208,10 @@ export const AppSEO = ({
     'Web3',
   ];
 
-  const categorySlug = category ? category.toLowerCase().replace(/\s+/g, '_').replace(/\W/g, '') : '';
+  const resolvedCategorySlug = categorySlug || (category ? category.toLowerCase().replace(/\s+/g, '_').replace(/\W/g, '') : '');
   const breadcrumbs: BreadcrumbItem[] = [
     { name: 'Home', url: DEFAULT_URL },
-    ...(category ? [{ name: category, url: `${DEFAULT_URL}/category/${categorySlug}` }] : []),
+    ...(category ? [{ name: category, url: `${DEFAULT_URL}/category/${resolvedCategorySlug}` }] : []),
     { name: appName, url: appUrl },
   ];
 

--- a/src/views/CategoryView.tsx
+++ b/src/views/CategoryView.tsx
@@ -6,6 +6,7 @@ import { Badge, Title } from '@mantine/core';
 import { ApplicationCardLargeV2 } from '../components/ApplicationCardLargeV2';
 import { Breadcrumb } from '../components/Breadcrumb';
 import { CategorySEO } from '../components/SEO';
+import { FourZeroFourView } from './FourZeroFourView';
 
 const fadeIn = keyframes({
   'from': { opacity: 0, transform: 'translateY(16px)' },
@@ -82,9 +83,11 @@ export const CategoryView = () => {
   let { id } = useParams();
   const [cards, setCards] = useState<JSX.Element[]>([]);
   const [category, setCategory] = useState<Category>();
+  const [isResolved, setIsResolved] = useState(false);
   const { classes } = useStyles();
 
   useEffect(() => {
+    setIsResolved(false);
     if (id === 'curated') {
       setCategory({
         value: 'curated',
@@ -95,8 +98,11 @@ export const CategoryView = () => {
       const category = appList.categories.find((category) => category.value === id);
       if (category) {
         setCategory(category);
+      } else {
+        setCategory(undefined);
       }
     }
+    setIsResolved(true);
   }, [id]);
 
   useEffect(() => {
@@ -129,8 +135,12 @@ export const CategoryView = () => {
           ))
         );
       }
+    } else {
+      setCards([]);
     }
   }, [category, classes.gridItem]);
+
+  if (!category && isResolved) return <FourZeroFourView />;
 
   return (
     <div className={classes.wrapper}>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Generate route-specific static HTML snapshots for app and category pages after the CRA build so crawlers receive correct titles, descriptions, canonicals, Open Graph/Twitter tags, and structured data before JavaScript runs.
- Align sitemap/category/app slug generation with the router and registry data.
- Render the noindex 404 view for unknown app/category routes instead of blank or thin 200 pages.
- Add canonical www-to-apex redirects for hosts that consume `_redirects`, and add popular app links to the no-JS fallback.

## Debug findings
- Live `https://solapps.dev/`, `/robots.txt`, and `/sitemap.xml` return 200 and do not include an `X-Robots-Tag` block.
- `robots.txt` allows `/` and declares the sitemap.
- Public search still returns some `solapps.dev/apps/*` pages, so this does not look like a complete Google deindex from repo-level robots/noindex.
- Live `https://www.solapps.dev/` returns Cloudflare 522 instead of redirecting to `https://solapps.dev/`; DNS/Cloudflare/origin config still needs to be fixed outside this repo.

## Validation
- `git diff --check`
- Build not run: this cloud image does not have `node`, `npm`, or `yarn` installed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0bfb0570-24b6-4768-a22a-9fb99c520429"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0bfb0570-24b6-4768-a22a-9fb99c520429"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

